### PR TITLE
move `slash` package to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "borp": "^0.9.0",
     "desm": "^1.3.0",
     "glob": "^10.3.10",
-    "slash": "^5.1.0",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0"
   },
   "dependencies": {
-    "find-up": "^7.0.0"
+    "find-up": "^7.0.0",
+    "slash": "^5.1.0"
   }
 }


### PR DESCRIPTION
I've moved the `slash` package to the `dependencies` section due to the `ERR_MODULE_NOT_FOUND` error encountered during the usage of the package.

To reproduce the issue, follow these steps:
* Check out the `main` branch.
* Remove the `node_modules` directory if it exists.
* Install dependencies with `npm i --omit=dev`.
* Run the `example.js` file with `node example.js`.